### PR TITLE
Configure LFCLK source to use 32.768Khz external oscillator

### DIFF
--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840_defconfig
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840_defconfig
@@ -25,3 +25,11 @@ CONFIG_UART_CONSOLE=y
 
 # additional board options
 CONFIG_GPIO_AS_PINRESET=y
+
+# Specific to beadedstream Spot Logger and D605N
+# (might want to make a separate board file at some point)
+
+# LFCLK/SYSTEM CLOCK/32.768Khz clock source
+CONFIG_CLOCK_CONTROL_NRF_K32SRC_EXT_FULL_SWING=y
+
+


### PR DESCRIPTION
* Default board configuration is set up for an external crystal. 
  Beadedstream's board uses an external oscillator.

  The bug manifests in the bootloader; at cold temps (less than -20F) the bootloader spins waiting for the LFCLK to switch from RC to   external oscillator.   This mod fixes that specific bug.  The   application already has the  correct setting for the LFCLK source   in prj.conf

  This configuration change was made directly to the nrf52840dk board file, because that's what beadedstream uses for their bootloader builds and I didn't want to have to change the build files and instructions. If beadedstream is going to make more changes to this board configuration I would think about maybe adding a specific board file board file for the bootloader ... that's up to you.